### PR TITLE
fix the deadlock problem when using distributed training in VQA fintune

### DIFF
--- a/oscar/run_vqa.py
+++ b/oscar/run_vqa.py
@@ -590,7 +590,7 @@ def train(args, train_dataset, eval_dataset, model, tokenizer):
                 model.zero_grad()
                 global_step += 1
 
-                if args.local_rank in [-1, 0] and args.logging_steps > 0 and global_step % args.logging_steps == 0:# Log metrics
+                if args.logging_steps > 0 and global_step % args.logging_steps == 0:# Log metrics
                     if args.local_rank not in [-1, 0]:
                         torch.distributed.barrier()
 


### PR DESCRIPTION
When using distributed training, the process with local_rank!=0 will not call torch.distributed.barrier() and cause a deadlock.